### PR TITLE
Budget service auth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -838,9 +838,9 @@ jwt.expiration=3600000
 
 9. Port Forwarding:
    ```bash
-   kubectl port-forward service/auth-api-service 8081:80
+   kubectl port-forward service/auth-api-service 8083:80
    ```
-- Access the API at http://localhost:8081/auth (e.g. `POST /auth/register`, `POST /auth/login`).
+- Access the API at http://localhost:8083/auth (e.g. `POST /auth/register`, `POST /auth/login`).
 ---
 ### Future Enhancements
 

--- a/README.md
+++ b/README.md
@@ -803,7 +803,8 @@ jwt.expiration=3600000
    - Build and load the local auth-api image into Kind:
 
     ```bash
-    docker build -t auth-api:latest ./auth-service
+    docker build -t auth-api .
+
     kind load docker-image auth-api:latest --name <cluster-name>
     ```
    - Make sure the `image:` field in `auth-deployment.yaml` matches (`auth-api:latest`).

--- a/README.md
+++ b/README.md
@@ -196,12 +196,12 @@ spring.jpa.properties.hibernate.format_sql=true
    ```
 
 7. Expose via NodePort (or Ingress):
-   - Your expense-service.yaml exposes the app on port 30080:
+   - Your expense-service.yaml exposes the app on port 30081:
 
    ```bash
    kubectl get svc expense-api-service
    ```
-   - You can now access the app at:http://<node-ip>:30080
+   - You can now access the app at:http://<node-ip>:30081
    
 
 8. Verify the Deployment:
@@ -220,9 +220,9 @@ spring.jpa.properties.hibernate.format_sql=true
 
 10. Port Forwarding:
    ```bash
-   kubectl port-forward service/expense-api-service 8080:80
+   kubectl port-forward service/expense-api-service 8081:80
    ```
-- Access the API at http://localhost:8080/api/expense.
+- Access the API at http://localhost:8081/api/expense.
 
 
 ## Investment Service
@@ -398,12 +398,12 @@ spring.jpa.properties.hibernate.format_sql=true
    ```
 
 7. Expose via NodePort (or Ingress):
-   - Your investment-service.yaml exposes the app on port 30080:
+   - Your investment-service.yaml exposes the app on port 30084:
 
    ```bash
    kubectl get svc investment-api-service
    ```
-   - You can now access the app at:http://<node-ip>:30080
+   - You can now access the app at:http://<node-ip>:30084
 
 
 8. Verify the Deployment:
@@ -421,10 +421,10 @@ spring.jpa.properties.hibernate.format_sql=true
 
 10. Port Forwarding:
    ```bash
-   kubectl port-forward service/investment-api-service 8080:80
+   kubectl port-forward service/investment-api-service 8084:80
    ```
 
-- Access the API at http://localhost:8080/api/investment.
+- Access the API at http://localhost:8084/api/investment.
 
 
 ### Budget Service
@@ -624,12 +624,12 @@ spring.jpa.properties.hibernate.format_sql=true
    ```
 
 7. Expose via NodePort (or Ingress):
-    - Your budget-service.yaml exposes the app on port 30080:
+    - Your budget-service.yaml exposes the app on port 30082:
 
    ```bash
    kubectl get svc budget-api-service
    ```
-    - You can now access the app at:http://<node-ip>:30080
+    - You can now access the app at:http://<node-ip>:30082
 
 
 8. Verify the Deployment:
@@ -647,10 +647,10 @@ spring.jpa.properties.hibernate.format_sql=true
    ```
 10. Port Forwarding:
    ```bash
-   kubectl port-forward service/budget-api-service 8080:80
+   kubectl port-forward service/budget-api-service 8082:80
    ```
 
-   - Access the API at http://localhost:8080/api/budget.
+   - Access the API at http://localhost:8082/api/budget.
 
 ## Auth Service
 
@@ -816,12 +816,12 @@ jwt.expiration=3600000
    ```
 
 6. Expose via NodePort (or Ingress):
-   - Your auth-service.yaml exposes the app on port 30080:
+   - Your auth-service.yaml exposes the app on port 30083:
 
    ```bash
    kubectl get svc auth-api-service
    ```
-   - You can now access the app at: http://<node-ip>:30080
+   - You can now access the app at: http://<node-ip>:30083
 
 7. Verify the Deployment:
    ```bash

--- a/auth-service/Dockerfile
+++ b/auth-service/Dockerfile
@@ -6,5 +6,5 @@ RUN mvn -f /home/app/pom.xml clean package
 FROM eclipse-temurin:17-jdk-alpine
 WORKDIR /app
 COPY --from=build /home/app/target/auth-0.0.1-SNAPSHOT.jar app.jar
-EXPOSE 8081
+EXPOSE 8083
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/auth-service/k8s/auth-deployment.yaml
+++ b/auth-service/k8s/auth-deployment.yaml
@@ -20,7 +20,7 @@ spec:
           image: auth-api:latest
           imagePullPolicy: Never
           ports:
-            - containerPort: 8081
+            - containerPort: 8083
           envFrom:
             - secretRef:
                 name: db-secrets

--- a/auth-service/k8s/auth-service.yaml
+++ b/auth-service/k8s/auth-service.yaml
@@ -9,6 +9,6 @@ spec:
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 8081
+      targetPort: 8083
       nodePort: 30080
   type: NodePort

--- a/auth-service/k8s/auth-service.yaml
+++ b/auth-service/k8s/auth-service.yaml
@@ -10,5 +10,5 @@ spec:
     - protocol: TCP
       port: 80
       targetPort: 8083
-      nodePort: 30080
+      nodePort: 30083
   type: NodePort

--- a/auth-service/src/main/resources/application.properties
+++ b/auth-service/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 spring.application.name=auth-service
 
-server.port=8081
+server.port=8083
 spring.datasource.url=${SPRING_DATASOURCE_URL}
 spring.datasource.username=${DB_USER}
 spring.datasource.password=${DB_PASSWORD}

--- a/budget-service/Dockerfile
+++ b/budget-service/Dockerfile
@@ -6,5 +6,5 @@ RUN mvn -f /home/app/pom.xml clean package -DskipTests
 FROM eclipse-temurin:17-jdk-alpine
 WORKDIR /app
 COPY --from=build /home/app/target/budget-0.0.1-SNAPSHOT.jar app.jar
-EXPOSE 8080
+EXPOSE 8082
 ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/budget-service/k8s/budget-deployment.yaml
+++ b/budget-service/k8s/budget-deployment.yaml
@@ -20,12 +20,12 @@ spec:
           image: budget-api:latest
           imagePullPolicy: Never
           ports:
-            - containerPort: 8080
+            - containerPort: 8082
           envFrom:
             - secretRef:
                 name: db-secrets
           env:
             - name: EXPENSE_SERVICE_URL
-              value: "http://expense-api-service:8081"
+              value: "http://expense-api-service:80"
             - name: INVESTMENT_SERVICE_URL
-              value: "http://investment-api-service:8082"
+              value: "http://investment-api-service:80"

--- a/budget-service/k8s/budget-service.yaml
+++ b/budget-service/k8s/budget-service.yaml
@@ -9,6 +9,6 @@ spec:
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 8080
-      nodePort: 30080
+      targetPort: 8082
+      nodePort: 30082
   type: NodePort

--- a/budget-service/pom.xml
+++ b/budget-service/pom.xml
@@ -79,6 +79,32 @@
 			<artifactId>spring-boot-starter-webmvc-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.12.5</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.12.5</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.12.5</version>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/budget-service/src/main/java/com/budget/security/JwtFilter.java
+++ b/budget-service/src/main/java/com/budget/security/JwtFilter.java
@@ -1,0 +1,51 @@
+package com.budget.security;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+
+    public JwtFilter(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String authHeader = request.getHeader("Authorization");
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = authHeader.substring(7);
+
+        if (jwtUtil.isTokenValid(token)) {
+            String username = jwtUtil.extractUsername(token);
+
+            UsernamePasswordAuthenticationToken authToken =
+                    new UsernamePasswordAuthenticationToken(username, null, List.of());
+            authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+            SecurityContextHolder.getContext().setAuthentication(authToken);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/budget-service/src/main/java/com/budget/security/JwtUtil.java
+++ b/budget-service/src/main/java/com/budget/security/JwtUtil.java
@@ -1,0 +1,62 @@
+package com.budget.security;
+
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.beans.factory.annotation.Value;
+
+@Component
+public class JwtUtil {
+
+
+    @Value("${jwt.secret}") 
+    private String secret;
+
+    @Value("${jwt.expiration}")
+    private long expiration;
+
+    private SecretKey getKey(){
+        return Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String generateToken(String username, String role) {
+        return Jwts.builder()
+                .subject(username)
+                .claim("role", role)
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + expiration))
+                .signWith(getKey())
+                .compact();
+    }
+
+    public String extractUsername(String token) {
+        return getClaims(token).getSubject();
+    }
+
+    public boolean isTokenValid(String token){
+        try{
+            getClaims(token);
+            return true;
+        }
+        catch(Exception e){
+            return false;
+        }
+    }
+
+    private Claims getClaims(String token){
+        return Jwts.parser()
+                .verifyWith(getKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+}

--- a/budget-service/src/main/java/com/budget/security/SecurityConfig.java
+++ b/budget-service/src/main/java/com/budget/security/SecurityConfig.java
@@ -1,0 +1,30 @@
+package com.budget.security;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Autowired
+    private JwtFilter jwtFilter;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth
+                .anyRequest().authenticated()
+            )
+            .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
+}

--- a/budget-service/src/main/java/com/budget/service/ExpenseServiceClient.java
+++ b/budget-service/src/main/java/com/budget/service/ExpenseServiceClient.java
@@ -1,6 +1,7 @@
 package com.budget.service;
 
 import com.budget.dto.ExpenseResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
@@ -14,6 +15,9 @@ public class ExpenseServiceClient {
     @Value("${expense.service.url:}")
     private String expenseServiceURL;
 
+    @Autowired
+    private HttpServletRequest request;
+
     private final RestClient restClient;
     @Autowired
     public ExpenseServiceClient(RestClient.Builder builder){
@@ -23,8 +27,12 @@ public class ExpenseServiceClient {
     public List<ExpenseResponse> getExpensesByMonth(int year, int month){
         String uri = "/api/expense/report/monthly?year={year}&month={month}";
 
+        String token = request.getHeader("Authorization");
+
+
         return restClient.get()
                 .uri(uri, year, month)
+                .header("Authorization", token)
                 .retrieve()
                 .body(new ParameterizedTypeReference<List<ExpenseResponse>>() {
         });

--- a/budget-service/src/main/java/com/budget/service/InvestmentServiceClient.java
+++ b/budget-service/src/main/java/com/budget/service/InvestmentServiceClient.java
@@ -2,13 +2,11 @@ package com.budget.service;
 
 import java.util.List;
 
-import com.budget.dto.ExpenseResponse;
-
 import com.budget.dto.InvestmentResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
 
@@ -17,6 +15,9 @@ public class InvestmentServiceClient {
 
     @Value("${investment.service.url:}")
     private String investmentServiceURL;
+
+    @Autowired
+    private HttpServletRequest request;
 
     private final RestClient restClient;
 
@@ -28,8 +29,11 @@ public class InvestmentServiceClient {
     public List<InvestmentResponse> getInvestmentsByMonth(int year, int month){
         String uri = "/api/investment/report/monthly?year={year}&month={month}";
 
+        String token = request.getHeader("Authorization");
+
         return restClient.get()
                 .uri(uri, year, month)
+                .header("Authorization", token)
                 .retrieve()
                 .body(new ParameterizedTypeReference<List<InvestmentResponse>>() {
         });

--- a/budget-service/src/main/resources/application.properties
+++ b/budget-service/src/main/resources/application.properties
@@ -1,3 +1,5 @@
+server.port=8082
+
 # PostgreSQL DB Configuration
 spring.datasource.url=${SPRING_DATASOURCE_URL}
 spring.datasource.username=${DB_USER}

--- a/budget-service/src/main/resources/application.properties
+++ b/budget-service/src/main/resources/application.properties
@@ -13,5 +13,6 @@ spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 
 jwt.secret=${JWT_SECRET:development-secret-key-minimum-32-bytes-long}
+jwt.expiration=${JWT_EXPIRATION:3600000}
 
   

--- a/budget-service/src/main/resources/application.properties
+++ b/budget-service/src/main/resources/application.properties
@@ -11,4 +11,7 @@ spring.jpa.hibernate.ddl-auto=update
 # Optional: Logging
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
+
+jwt.secret=${JWT_SECRET:development-secret-key-minimum-32-bytes-long}
+
   

--- a/budget-service/src/test/java/com/budget/controller/GlobalExceptionHandlerTest.java
+++ b/budget-service/src/test/java/com/budget/controller/GlobalExceptionHandlerTest.java
@@ -1,9 +1,11 @@
 package com.budget.controller;
 
 import com.budget.exception.BudgetNotFoundException;
+import com.budget.security.JwtUtil;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -16,6 +18,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(BudgetController.class)
+@WithMockUser
 public class GlobalExceptionHandlerTest {
 
     @Autowired
@@ -23,6 +26,9 @@ public class GlobalExceptionHandlerTest {
 
     @MockitoBean
     private BudgetService budgetService;
+
+    @MockitoBean
+    private JwtUtil jwtUtil;
 
     @Test
     void BudgetNotFoundException_Returns404Not_Found() throws Exception{

--- a/budget-service/src/test/resources/application-test.properties
+++ b/budget-service/src/test/resources/application-test.properties
@@ -5,3 +5,5 @@ spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=
 spring.jpa.hibernate.ddl-auto=update
+jwt.secret=test-secret-key-minimum-32-bytes-long-for-testing
+jwt.expiration=3600000

--- a/expense-service/Dockerfile
+++ b/expense-service/Dockerfile
@@ -6,5 +6,5 @@ RUN mvn -f /home/app/pom.xml clean package
 FROM openjdk:17-jdk-slim
 WORKDIR /app
 COPY --from=build /home/app/target/expense-0.0.1-SNAPSHOT.jar app.jar
-EXPOSE 8080
+EXPOSE 8081
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/expense-service/k8s/expense-deployment.yaml
+++ b/expense-service/k8s/expense-deployment.yaml
@@ -20,7 +20,7 @@ spec:
           image: expense-api:latest
           imagePullPolicy: Never
           ports:
-            - containerPort: 8080
+            - containerPort: 8081
           envFrom:
             - secretRef:
                 name: db-secrets

--- a/expense-service/k8s/expense-service.yaml
+++ b/expense-service/k8s/expense-service.yaml
@@ -9,6 +9,6 @@ spec:
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 8080
-      nodePort: 30080
+      targetPort: 8081
+      nodePort: 30081
   type: NodePort

--- a/expense-service/src/main/resources/application.properties
+++ b/expense-service/src/main/resources/application.properties
@@ -7,6 +7,8 @@
 #spring.h2.console.enabled=true
 #spring.jpa.hibernate.ddl-auto=update
 
+server.port=8081
+
 # PostgreSQL DB Configuration
 spring.datasource.url=${SPRING_DATASOURCE_URL}
 spring.datasource.username=${DB_USER}

--- a/investment-service/Dockerfile
+++ b/investment-service/Dockerfile
@@ -6,5 +6,5 @@ RUN mvn -f /home/app/pom.xml clean package -DskipTests
 FROM eclipse-temurin:17-jdk-alpine
 WORKDIR /app
 COPY --from=build /home/app/target/investment-0.0.1-SNAPSHOT.jar app.jar
-EXPOSE 8080
+EXPOSE 8084
 ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/investment-service/k8s/investment-deployment.yaml
+++ b/investment-service/k8s/investment-deployment.yaml
@@ -20,7 +20,7 @@ spec:
           image: investment-api:latest
           imagePullPolicy: Never
           ports:
-            - containerPort: 8080
+            - containerPort: 8084
           envFrom:
             - secretRef:
                 name: db-secrets

--- a/investment-service/k8s/investment-service.yaml
+++ b/investment-service/k8s/investment-service.yaml
@@ -9,6 +9,6 @@ spec:
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 8080
-      nodePort: 30080
+      targetPort: 8084
+      nodePort: 30084
   type: NodePort

--- a/investment-service/src/main/resources/application.properties
+++ b/investment-service/src/main/resources/application.properties
@@ -1,5 +1,7 @@
 # spring.application.name=investment-service
 
+server.port=8084
+
 # PostgreSQL DB Configuration
 spring.datasource.url=${SPRING_DATASOURCE_URL}
 spring.datasource.username=${DB_USER}


### PR DESCRIPTION
### Summary
Implemented JWT authentication and authorization in the budget service by adding JwtFilter, JwtUtil, and SecurityConfig classes
Updated all service clients (ExpenseServiceClient, InvestmentServiceClient) to include Authorization headers when making inter-service calls
Added JWT configuration properties (jwt.secret, jwt.expiration) to budget-service application.properties
Aligned Kubernetes deployment configs and Dockerfiles with updated port assignments across all services (auth, budget, expense, investment)
Updated README to reflect the correct service ports

### Changes by area
**Budget Service — Auth**

JwtFilter: validates Bearer tokens on incoming requests
JwtUtil: handles token parsing and claims extraction
SecurityConfig: configures Spring Security to use the JWT filter

**Service-to-Service Calls**

ExpenseServiceClient and InvestmentServiceClient now forward the JWT token via Authorization header

**Infrastructure**

Corrected container/target ports in K8s manifests and Dockerfiles for all four services
README port table updated accordingly