### PR TITLE
Add JWT authentication support to expense-service

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,21 @@ The Personal-Finance-Platform consists of four microservices:
 - **Validation**: Spring Validation
 - **Future Plans**: Spring Security, Docker, API Gateway, Service Discovery
 
+# Auto Deploy of All Services
+Usage:
+
+```
+./deploy.sh <cluster-name>   # defaults to "finance-cluster" if omitted
+```
+
+What it automates (in order):
+
+Creates the Kind cluster if it doesn't exist yet (skips if already running)
+Runs mvn clean package for all 4 services
+Builds Docker images and loads them into Kind
+Applies DB secrets + Postgres manifests per service
+Deploys the apps — auth, expense, investment first, then budget last (since it depends on the other two)
+Prints a full status report and the port-forward commands at the end
 # Detailed Description of Each Service
 
 ## Expense Service

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -e
+
+# Usage: ./deploy.sh <cluster-name>
+CLUSTER_NAME=${1:-finance-cluster}
+
+SERVICES=("auth-service" "expense-service" "investment-service" "budget-service")
+IMAGES=("auth-api" "expense-api" "investment-api" "budget-api")
+
+# ── 1. Ensure cluster exists ────────────────────────────────────────────────
+if ! kind get clusters 2>/dev/null | grep -q "^${CLUSTER_NAME}$"; then
+  echo ">>> Creating Kind cluster '${CLUSTER_NAME}'..."
+  kind create cluster --name "$CLUSTER_NAME"
+else
+  echo ">>> Cluster '${CLUSTER_NAME}' already exists, skipping creation."
+fi
+
+# ── 2. Build Maven artifacts ─────────────────────────────────────────────────
+echo ""
+echo ">>> Building all services with Maven..."
+for service in "${SERVICES[@]}"; do
+  echo "    Building ${service}..."
+  (cd "$service" && mvn clean package -q -DskipTests)
+done
+
+# ── 3. Build Docker images & load into Kind ──────────────────────────────────
+echo ""
+echo ">>> Building Docker images and loading into Kind..."
+for i in "${!SERVICES[@]}"; do
+  service="${SERVICES[$i]}"
+  image="${IMAGES[$i]}"
+  echo "    ${service} → ${image}:latest"
+  docker build -t "${image}:latest" "$service"
+  kind load docker-image "${image}:latest" --name "$CLUSTER_NAME"
+done
+
+# ── 4. Apply shared DB secrets & Postgres per service ───────────────────────
+echo ""
+echo ">>> Applying DB secrets and Postgres deployments..."
+for service in "${SERVICES[@]}"; do
+  echo "    ${service}..."
+  kubectl apply -f "${service}/k8s/db-secrets.yaml"
+  kubectl apply -f "${service}/k8s/postgres-deployment.yaml"
+  kubectl apply -f "${service}/k8s/postgres-service.yaml"
+done
+
+# ── 5. Deploy services (budget last — depends on expense + investment) ───────
+echo ""
+echo ">>> Deploying application services..."
+for service in "${SERVICES[@]}"; do
+  name="${service%-service}"   # e.g. "expense-service" → "expense"
+  echo "    Deploying ${service}..."
+  kubectl apply -f "${service}/k8s/${name}-deployment.yaml"
+  kubectl apply -f "${service}/k8s/${name}-service.yaml"
+done
+
+# ── 6. Verify ────────────────────────────────────────────────────────────────
+echo ""
+echo ">>> Deployment complete. Current cluster state:"
+kubectl get deployments
+echo ""
+kubectl get pods
+echo ""
+kubectl get services
+echo ""
+echo "Port-forward commands:"
+echo "  kubectl port-forward service/auth-api-service     8083:80"
+echo "  kubectl port-forward service/expense-api-service  8081:80"
+echo "  kubectl port-forward service/investment-api-service 8084:80"
+echo "  kubectl port-forward service/budget-api-service   8082:80"

--- a/expense-service/pom.xml
+++ b/expense-service/pom.xml
@@ -64,6 +64,32 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.12.5</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.12.5</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.12.5</version>
+			<scope>runtime</scope>
+		</dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>

--- a/expense-service/src/main/java/com/example/expense/security/JwtFilter.java
+++ b/expense-service/src/main/java/com/example/expense/security/JwtFilter.java
@@ -1,0 +1,53 @@
+package com.example.expense.security;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class JwtFilter extends OncePerRequestFilter{
+
+    private final JwtUtil jwtUtil;
+
+    public JwtFilter(JwtUtil jwtUtil){
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) 
+    throws ServletException, IOException{
+
+        String authHeader = request.getHeader("Authorization");
+
+        if((authHeader == null)|| !authHeader.startsWith("Bearer ")){
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = authHeader.substring(7);
+
+        if (jwtUtil.isTokenValid(token)) {
+            String username = jwtUtil.extractUsername(token);
+
+            UsernamePasswordAuthenticationToken authToken =
+                    new UsernamePasswordAuthenticationToken(username, null, List.of());
+            authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+            SecurityContextHolder.getContext().setAuthentication(authToken);
+        }
+
+        filterChain.doFilter(request, response);
+
+    }
+
+}

--- a/expense-service/src/main/java/com/example/expense/security/JwtUtil.java
+++ b/expense-service/src/main/java/com/example/expense/security/JwtUtil.java
@@ -1,0 +1,59 @@
+package com.example.expense.security;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+
+@Component
+public class JwtUtil {
+
+    @Value("${jwt.secret}") 
+    private String secret;
+
+    @Value("${jwt.expiration}")
+    private long expiration;
+
+    private SecretKey getKey(){
+        return Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String generateToken(String username, String role){
+        return Jwts.builder()
+                    .subject(username)
+                    .claim("role", role)
+                    .issuedAt(new Date())
+                    .expiration(new Date(System.currentTimeMillis() + expiration))
+                    .signWith(getKey())
+                    .compact();
+    }
+
+    public String extractUsername(String token){
+        return getClaims(token).getSubject();
+    }
+
+    public boolean isTokenValid(String token){
+        try{
+            getClaims(token);
+            return true;
+        }
+        catch(Exception e){
+            return false;
+        }
+    }
+
+    private Claims getClaims(String token){
+        return Jwts.parser()
+                    .verifyWith(getKey())
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+    }
+}

--- a/expense-service/src/main/java/com/example/expense/security/SecurityConfig.java
+++ b/expense-service/src/main/java/com/example/expense/security/SecurityConfig.java
@@ -1,0 +1,27 @@
+package com.example.expense.security;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Autowired
+    private JwtFilter jwtFilter; 
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
+        http
+        .csrf( csrf -> csrf.disable())
+        .sessionManagement(s->s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .authorizeHttpRequests(auth -> auth.anyRequest().authenticated()).addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
+}

--- a/expense-service/src/main/java/com/example/expense/security/SecurityConfig.java
+++ b/expense-service/src/main/java/com/example/expense/security/SecurityConfig.java
@@ -21,7 +21,8 @@ public class SecurityConfig {
         http
         .csrf( csrf -> csrf.disable())
         .sessionManagement(s->s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-        .authorizeHttpRequests(auth -> auth.anyRequest().authenticated()).addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+        .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+        .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 }

--- a/expense-service/src/main/resources/application.properties
+++ b/expense-service/src/main/resources/application.properties
@@ -1,12 +1,3 @@
-#spring.application.name=expense-service
-#spring.datasource.url=jdbc:h2:mem:testdb
-#spring.datasource.driverClassName=org.h2.Driver
-#spring.datasource.username=sa
-#spring.datasource.password=
-#spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
-#spring.h2.console.enabled=true
-#spring.jpa.hibernate.ddl-auto=update
-
 server.port=8081
 
 # PostgreSQL DB Configuration
@@ -22,3 +13,6 @@ spring.jpa.hibernate.ddl-auto=update
 # Optional: Logging
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
+
+jwt.secret=${JWT_SECRET:development-secret-key-minimum-32-bytes-long}
+jwt.expiration=${JWT_EXPIRATION:3600000}

--- a/expense-service/src/test/java/com/example/expense/controller/GlobalExceptionHandlerTest.java
+++ b/expense-service/src/test/java/com/example/expense/controller/GlobalExceptionHandlerTest.java
@@ -1,22 +1,26 @@
 package com.example.expense.controller;
 
 import com.example.expense.exception.ExpenseNotFoundException;
+import com.example.expense.security.JwtUtil;
 import com.example.expense.service.ExpenseService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ExpenseController.class)
+@WithMockUser
 public class GlobalExceptionHandlerTest {
 
     @Autowired
@@ -24,6 +28,9 @@ public class GlobalExceptionHandlerTest {
 
     @MockitoBean
     private ExpenseService expenseService;
+
+    @MockitoBean
+    private JwtUtil jwtUtil;
 
     @Test
     void expenseNotFoundException_Return404_WhenExpenseNotFound() throws Exception{
@@ -40,7 +47,7 @@ public class GlobalExceptionHandlerTest {
     void DataIntegrityViolationException_Return400_WhenFailedToDeleteExpense() throws Exception{
         doThrow(new DataIntegrityViolationException("")).when(expenseService).removeExpense(1L);
 
-        mockMvc.perform(delete("/api/expense/1"))
+        mockMvc.perform(delete("/api/expense/1").with(csrf()))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(400))
                 .andExpect(jsonPath("$.message").value("Failed to delete Expense, the register is in use: "));


### PR DESCRIPTION
## Add JWT authentication support to expense-service

## Summary
- Adds JWT-based authentication to the expense-service using Spring Security (`JwtFilter`, `JwtUtil`, `SecurityConfig`)
- All endpoints are now protected and require a valid Bearer token; token secret and expiration are configurable via environment variables (`JWT_SECRET`, `JWT_EXPIRATION`)
- Adds a `deploy.sh` script to automate full cluster deployment (Kind cluster creation, Maven builds, Docker image builds, and Kubernetes manifests application) for all four services
- Updates `GlobalExceptionHandlerTest` to work with the new security layer (`@WithMockUser`, `JwtUtil` mock, CSRF support)

## Test plan
- [ ] Run `mvn test` in `expense-service` — all existing tests should pass with the security context in place
- [ ] Start the service and confirm unauthenticated requests to `/api/expense/**` return `401`
- [ ] Generate a token via `JwtUtil.generateToken` and confirm authenticated requests succeed
- [ ] Run `./deploy.sh` against a local Kind cluster and verify all pods reach `Running` state
